### PR TITLE
Kubelet plugin fixes

### DIFF
--- a/scripts/opencontrail-kubelet/opencontrail_kubelet/plugin.py
+++ b/scripts/opencontrail-kubelet/opencontrail_kubelet/plugin.py
@@ -7,6 +7,7 @@ import iniparse
 import json
 import logging
 import os
+import platform
 import re
 import requests
 import socket
@@ -169,7 +170,10 @@ def setup(pod_namespace, pod_name, docker_id):
               (short_id, gateway))
     Shell.run('ip netns exec %s ip link set %s up' %
               (short_id, instance_ifname))
-    Shell.run('nsenter -n -t %d ethtool -K %s tx off' % (pid, instance_ifname))
+    # TX checksum is broken on Fedora 21 testbed.
+    # This may be an issue with kernel 3.17 or veth-pair code.
+    if platform.linux_distribution()[0:2] == ('Fedora', '21'):
+        Shell.run('nsenter -n -t %d ethtool -K %s tx off' % (pid, instance_ifname))
 
 def vrouter_interface_by_name(vmName):
     r = requests.get('http://localhost:8085/Snh_ItfReq')

--- a/scripts/opencontrail-kubelet/opencontrail_kubelet/plugin.py
+++ b/scripts/opencontrail-kubelet/opencontrail_kubelet/plugin.py
@@ -12,6 +12,7 @@ import requests
 import socket
 import subprocess
 import sys
+import time
 import uuid
 import xml.etree.ElementTree as ElementTree
 
@@ -214,12 +215,16 @@ def main():
 
     args = parser.parse_args()
 
-    if args.action == 'init':
-        plugin_init()
-    elif args.action == 'setup':
-        setup(args.pod_namespace, args.pod_name, args.docker_id)
-    elif args.action == 'teardown':
-        teardown(args.pod_namespace, args.pod_name, args.docker_id)
+    try:
+        if args.action == 'init':
+            plugin_init()
+        elif args.action == 'setup':
+            setup(args.pod_namespace, args.pod_name, args.docker_id)
+        elif args.action == 'teardown':
+            teardown(args.pod_namespace, args.pod_name, args.docker_id)
+    except Exception as ex:
+        logging.error(ex)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Retry the fetch of metadata from the k8s api server until it contains the nic-uuid.
- Disable TX offload on Fedora 21.