### PR TITLE
Remove command-line arguments from vrouter agent

### DIFF
--- a/cluster/contrail-vrouter-agent.manifest
+++ b/cluster/contrail-vrouter-agent.manifest
@@ -7,12 +7,9 @@
 	"containers":[{
 	    "name": "contrail-vrouter-agent",
 	    "image": "opencontrail/vrouter-agent:2.20",
-	    "privileged": "true",
 	    "command": ["/usr/bin/contrail-vrouter-agent"],
 	    "securityContext": {
-	    	"capabilities": {
-		    "add": ["NET_BIND_SERVICE"]
-		}
+	        "privileged": true
 	    },
 	    "ports": [{
 		"name": "vrouter-api",


### PR DESCRIPTION
The "privileged" tag is now under securityContext.