### PR TITLE
Ignore pods that use the host network

### DIFF
--- a/pkg/network/opencontrail/mocks/Store.go
+++ b/pkg/network/opencontrail/mocks/Store.go
@@ -71,8 +71,8 @@ func (m *Store) GetByKey(key string) (interface{}, bool, error) {
 
 	return r0, r1, r2
 }
-func (m *Store) Replace(_a0 []interface{}) error {
-	ret := m.Called(_a0)
+func (m *Store) Replace(_a0 []interface{}, _a1 string) error {
+	ret := m.Called(_a0, _a1)
 
 	r0 := ret.Error(0)
 


### PR DESCRIPTION
Ignore pods that use the host network;  we may have to  ignore additional pods such as ones running on the master.