### PR TITLE
Fix configuration file parsing.

### DIFF
--- a/cmd/kube-network-manager/app/server.go
+++ b/cmd/kube-network-manager/app/server.go
@@ -89,7 +89,17 @@ func (m *NetworkManager) parseConfig() io.ReadCloser {
 		glog.Warning(err)
 		return nil
 	}
-	network.ReadConfiguration(file, &m.config)
+
+	err = network.ReadConfiguration(file, &m.config)
+	if err != nil {
+		glog.Error(err)
+	}
+
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		glog.Error(err)
+	}
+
 	return file
 }
 

--- a/pkg/network/config_test.go
+++ b/pkg/network/config_test.go
@@ -26,6 +26,9 @@ func TestMaster(t *testing.T) {
 	configData := `
 [DEFAULT]
 master = https://master:443
+
+[opencontrail]
+option = value
 `
 	buffer := bytes.NewBufferString(configData)
 	var config Config

--- a/pkg/network/opencontrail/config.go
+++ b/pkg/network/opencontrail/config.go
@@ -91,6 +91,7 @@ func (c *Config) Parse(args []string) {
 }
 
 type configWrapper struct {
+	Default      network.Config
 	OpenContrail Config
 }
 

--- a/pkg/network/opencontrail/config_test.go
+++ b/pkg/network/opencontrail/config_test.go
@@ -34,6 +34,9 @@ func TestParse(t *testing.T) {
 
 func TestConfigFile(t *testing.T) {
 	content := `
+[DEFAULT]
+service-cluster-ip-range = 10.253.0.0/16
+
 [opencontrail]
 api-server = master
 network-label = k8-app

--- a/pkg/network/opencontrail/opencontrail.go
+++ b/pkg/network/opencontrail/opencontrail.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/client/cache"
 	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
 
@@ -59,8 +61,13 @@ func NewController(kube *kubeclient.Client, args []string) network.NetworkContro
 func (c *Controller) Init(global *network.Config, reader io.Reader) error {
 	err := c.config.ReadConfiguration(global, reader)
 	if err != nil {
-		return err
+		glog.Error(err)
 	}
+
+	glog.Infof("Starting opencontrail plugin")
+	glog.Infof("Private Subnet:  %s", c.config.PrivateSubnet)
+	glog.Infof("Services Subnet: %s", c.config.ServiceSubnet)
+	glog.Infof("Public Subnet:   %s", c.config.PublicSubnet)
 
 	client := contrail.NewClient(c.config.ApiAddress, c.config.ApiPort)
 	c.client = client


### PR DESCRIPTION
Ignore sections other than the default when parsing configuration for
main module. Rewind the configuration file before attempting the second
read.