### PR TITLE
Introduce cluster wide service configuration

### DIFF
--- a/pkg/network/opencontrail/config_test.go
+++ b/pkg/network/opencontrail/config_test.go
@@ -18,6 +18,7 @@ package opencontrail
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,5 +57,30 @@ public-ip-range = 192.168.0.0/24
 	}
 	if config.PublicSubnet != "192.168.0.0/24" {
 		t.Errorf("expected 192.168.0.0/24, got %s", config.PublicSubnet)
+	}
+}
+
+func TestClusterServices(t *testing.T) {
+	content := `
+[opencontrail]
+cluster-service = kube-system/dns
+cluster-service = kube-system/monitoring
+`
+	buffer := bytes.NewBufferString(content)
+	config := NewConfig()
+	err := config.ReadConfiguration(nil, buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.ClusterServices) != 2 {
+		t.Errorf("expected 2 entries in cluster-services list, got %d", len(config.ClusterServices))
+	}
+	values := []string{"dns", "monitoring"}
+	for i, v := range values {
+		fqn := strings.Split(config.ClusterServices[i], "/")
+		if fqn[len(fqn)-1] != v {
+			t.Errorf("expected %s, got %s", v, fqn[len(fqn)-1])
+		}
 	}
 }

--- a/pkg/network/opencontrail/controller_test.go
+++ b/pkg/network/opencontrail/controller_test.go
@@ -46,6 +46,17 @@ func testKeyFunc(obj interface{}) (string, error) {
 	return "", nil
 }
 
+func createTestClient() contrail.ApiClient {
+	client := new(contrail_mocks.ApiClient)
+	client.Init()
+
+	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
+	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
+	client.AddInterceptor("instance-ip", &IpInterceptor{})
+	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
+	return client
+}
+
 func NewTestController(kube kubeclient.Interface, client contrail.ApiClient, allocator AddressAllocator, networkMgr NetworkManager) *Controller {
 	controller := new(Controller)
 	controller.serviceStore = cache.NewStore(testKeyFunc)
@@ -624,9 +635,9 @@ func TestPodUsesService(t *testing.T) {
 	assert.NoError(t, err)
 
 	poRefs, err := serviceNet.GetNetworkPolicyRefs()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, poRefs)
-	assert.Equal(t, policy.GetUuid(), poRefs[0].Uuid)
+	if assert.NoError(t, err) && assert.NotEmpty(t, poRefs) {
+		assert.Equal(t, policy.GetUuid(), poRefs[0].Uuid)
+	}
 
 	controller.AddPod(pod2)
 	time.Sleep(100 * time.Millisecond)
@@ -635,9 +646,9 @@ func TestPodUsesService(t *testing.T) {
 	assert.NoError(t, err)
 
 	clientRefs, err := clientNet.GetNetworkPolicyRefs()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, clientRefs)
-	assert.Equal(t, policy.GetUuid(), clientRefs[0].Uuid)
+	if assert.NoError(t, err) && assert.NotEmpty(t, clientRefs) {
+		assert.Equal(t, policy.GetUuid(), clientRefs[0].Uuid)
+	}
 
 	policy, err = types.NetworkPolicyByName(client, "default-domain:testns:x1")
 	if err == nil {
@@ -765,9 +776,9 @@ func TestPodUsesServiceCreatedAfter(t *testing.T) {
 	assert.NoError(t, err)
 
 	clientRefs, err := clientNet.GetNetworkPolicyRefs()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, clientRefs)
-	assert.Equal(t, policy.GetUuid(), clientRefs[0].Uuid)
+	if assert.NoError(t, err) && assert.NotEmpty(t, clientRefs) {
+		assert.Equal(t, policy.GetUuid(), clientRefs[0].Uuid)
+	}
 
 	controller.AddPod(pod1)
 	controller.AddService(service)
@@ -778,9 +789,9 @@ func TestPodUsesServiceCreatedAfter(t *testing.T) {
 	assert.NoError(t, err)
 
 	poRefs, err := serviceNet.GetNetworkPolicyRefs()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, poRefs)
-	assert.Equal(t, policy.GetUuid(), poRefs[0].Uuid)
+	if assert.NoError(t, err) && assert.NotEmpty(t, poRefs) {
+		assert.Equal(t, policy.GetUuid(), poRefs[0].Uuid)
+	}
 
 	policy, err = types.NetworkPolicyByName(client, "default-domain:testns:x1")
 	assert.NoError(t, err)
@@ -1158,14 +1169,7 @@ func TestServiceWithMultipleBackends(t *testing.T) {
 func TestServiceWithLoadBalancer(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	pod1 := &api.Pod{
@@ -1282,14 +1286,7 @@ func getReferenceListNames(refs contrail.ReferenceList) []string {
 func TestServiceUpdateSelector(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	pod1 := &api.Pod{
@@ -1428,14 +1425,7 @@ func TestServiceUpdateSelector(t *testing.T) {
 func TestServiceUpdateLabel(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	pod1 := &api.Pod{
@@ -1582,14 +1572,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 func TestServiceUpdatePublicIp(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	pod1 := &api.Pod{
@@ -1715,14 +1698,7 @@ func TestServiceUpdatePublicIp(t *testing.T) {
 func TestNetworkWithMultipleServices(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	store := new(mocks.Store)
@@ -1883,14 +1859,7 @@ func TestNetworkWithMultipleServices(t *testing.T) {
 func TestPodSelectedBy2Services(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	store := new(mocks.Store)
@@ -2006,14 +1975,7 @@ func TestPodSelectedBy2Services(t *testing.T) {
 func TestPodUsing2Services(t *testing.T) {
 	kube := mocks.NewKubeClient()
 
-	client := new(contrail_mocks.ApiClient)
-	client.Init()
-
-	client.AddInterceptor("virtual-machine-interface", &VmiInterceptor{})
-	client.AddInterceptor("virtual-network", &NetworkInterceptor{})
-	client.AddInterceptor("instance-ip", &IpInterceptor{})
-	client.AddInterceptor("floating-ip", &FloatingIpInterceptor{})
-
+	client := createTestClient()
 	controller := NewTestController(kube, client, nil, nil)
 
 	store := new(mocks.Store)

--- a/pkg/network/opencontrail/network.go
+++ b/pkg/network/opencontrail/network.go
@@ -168,7 +168,7 @@ func (m *NetworkManagerImpl) LookupNetwork(projectName, networkName string) (*ty
 	fqn := []string{DefaultDomain, projectName, networkName}
 	obj, err := m.client.FindByName("virtual-network", strings.Join(fqn, ":"))
 	if err != nil {
-		glog.Errorf("GET virtual-network %s: %v", networkName, err)
+		glog.V(3).Infof("GET virtual-network %s: %v", networkName, err)
 		return nil, err
 	}
 	return obj.(*types.VirtualNetwork), nil

--- a/pkg/network/opencontrail/service_test.go
+++ b/pkg/network/opencontrail/service_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2015 Juniper Networks, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opencontrail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	contrail_mocks "github.com/Juniper/contrail-go-api/mocks"
+	"github.com/Juniper/contrail-go-api/types"
+)
+
+func TestPurgeServiceList(t *testing.T) {
+	client := new(contrail_mocks.ApiClient)
+	client.Init()
+
+	config := NewConfig()
+	networkMgr := NewNetworkManager(client, config)
+	serviceMgr := NewServiceManager(client, config, networkMgr)
+
+	netnsProject := new(types.Project)
+	netnsProject.SetFQName("", []string{"default-domain", "testns"})
+	client.Create(netnsProject)
+
+	globalProject := new(types.Project)
+	globalProject.SetFQName("", []string{"default-domain", "global"})
+	client.Create(globalProject)
+
+	network, err := networkMgr.LocateNetwork("testns", "client", config.PrivateSubnet)
+
+	services := []string{
+		"testns/s1",
+		"testns/s2",
+		"global/s3",
+		"global/s4",
+	}
+
+	for _, svc := range services {
+		parts := strings.Split(svc, "/")
+		namespace := parts[0]
+		svcName := parts[1]
+		err := serviceMgr.Create(namespace, svcName)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		err = serviceMgr.Connect(namespace, svcName, network)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	serviceList := MakeServiceIdList()
+	serviceList.Add("testns", "s1")
+	serviceList.Add("global", "s3")
+
+	err = serviceMgr.PurgeStalePolicyRefs(network, serviceList,
+		func(namespace, name string) bool {
+			return true
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := network.GetNetworkPolicyRefs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != len(serviceList) {
+		t.Errorf("expected %d policy refs, got %d", len(serviceList), len(refs))
+	}
+	actual := make([]string, 0)
+	for _, ref := range refs {
+		actual = append(actual, ref.To[1]+"/"+ref.To[2])
+	}
+	assert.EqualValues(t, []string{"testns/s1", "global/s3"}, actual)
+}

--- a/pkg/network/opencontrail/util.go
+++ b/pkg/network/opencontrail/util.go
@@ -21,6 +21,38 @@ import (
 	"strings"
 )
 
+type ServiceId struct {
+	Namespace string
+	Service   string
+}
+
+type ServiceIdList []ServiceId
+
+func (s *ServiceIdList) Contains(namespace, service string) bool {
+	for _, entry := range *s {
+		if entry.Namespace == namespace && entry.Service == service {
+			return true
+		}
+	}
+	return false
+}
+func (s *ServiceIdList) Add(namespace, service string) {
+	if s.Contains(namespace, service) {
+		return
+	}
+	*s = append(*s, ServiceId{namespace, service})
+}
+
+func MakeServiceIdList() ServiceIdList {
+	return make(ServiceIdList, 0)
+}
+
+// serviceIdFromName splits a prevalidated string in the form namespace/service-name.
+func serviceIdFromName(name string) (string, string) {
+	tuple := strings.Split(name, "/")
+	return tuple[0], tuple[1]
+}
+
 func AppendConst(slice []string, element string) []string {
 	newSlice := make([]string, len(slice), len(slice)+1)
 	copy(newSlice, slice)

--- a/pkg/network/opencontrail/util_test.go
+++ b/pkg/network/opencontrail/util_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2015 Juniper Networks, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opencontrail
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestServiceIdList(t *testing.T) {
+	config := NewConfig()
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "test-xz1",
+			Namespace: "testns",
+			Labels: map[string]string{
+				"name": "testpod",
+				"uses": "service1",
+			},
+		},
+	}
+
+	list := MakeServiceIdList()
+
+	// ServiceIdList is a slice; it must be passed as a pointer in order to be
+	// modified.
+	BuildPodServiceList(pod, config, &list)
+
+	if len(list) != 1 {
+		t.Errorf("expected list length 1, got %d", len(list))
+	}
+	names := make([]string, 0)
+	for _, v := range list {
+		names = append(names, v.Service)
+	}
+	if !reflect.DeepEqual(names, []string{"service1"}) {
+		t.Errorf("expected [\"service1\"], got %+v", names)
+	}
+}


### PR DESCRIPTION
New configuration statement under the [opencontrail] section can be used to define services that are accessed by all pods, irrespective of their namespace and network.

Example:
```
[opencontrail]
cluster-service = kube-system/dns
cluster-service = kube-system/monitoring
```

This PR also adds code that removes connections between pod networks and services which are no longer in use according to either labels (in pod spec) or global cluster-services.