### PR TITLE
Support .kubeconfig files for authentication and cluster settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - wget https://github.com/Juniper/contrail-go-api/releases/download/1.0.0/contrail-go-api-generated-types-r2.20.tar.gz
   - tar -zxvf contrail-go-api-generated-types-r2.20.tar.gz -C ${GOPATH}/src
   - mkdir -p ${GOPATH}/src/k8s.io
-  - (cd ${GOPATH}/src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git)
+  - (cd ${GOPATH}/src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git -b v1.1.0)
   - go get code.google.com/p/go-uuid/uuid
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/axw/gocov/gocov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opencontrail/go-k8s-builder
+FROM opencontrail/go-k8s-builder:1.1.0
 MAINTAINER Pedro Marques <roque@juniper.net>
 RUN mkdir -p src/github.com/Juniper/contrail-kubernetes
 ADD cmd /go/src/github.com/Juniper/contrail-kubernetes/cmd

--- a/pkg/network/config.go
+++ b/pkg/network/config.go
@@ -30,6 +30,7 @@ import (
 
 type Config struct {
 	KubeUrl        string        `gcfg:"master"`
+	KubeConfig     string        `gcfg:"kubeconfig"`
 	ResyncPeriod   time.Duration `gcfg:"resync-interval"`
 	ClusterIpRange string        `gcfg:"service-cluster-ip-range"`
 }

--- a/scripts/go-k8s-builder/Dockerfile
+++ b/scripts/go-k8s-builder/Dockerfile
@@ -5,4 +5,4 @@ RUN (cd src/github.com/Juniper && git clone https://github.com/Juniper/contrail-
 RUN wget https://github.com/Juniper/contrail-go-api/releases/download/1.0.0/contrail-go-api-generated-types-r2.20.tar.gz
 RUN (cd src && tar zxvf ../contrail-go-api-generated-types-r2.20.tar.gz)
 RUN mkdir -p src/k8s.io
-RUN (cd src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git)
+RUN (cd src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git -b v1.1.0)


### PR DESCRIPTION
Use the clientcmd API in order to read a kubeconfig file to configure the k8s client.