### PR TITLE
Ensure that the code compiles with the kubernetes master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - wget https://github.com/Juniper/contrail-go-api/releases/download/1.0.0/contrail-go-api-generated-types-r2.20.tar.gz
   - tar -zxvf contrail-go-api-generated-types-r2.20.tar.gz -C ${GOPATH}/src
   - mkdir -p ${GOPATH}/src/k8s.io
-  - (cd ${GOPATH}/src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git -b v1.1.0)
+  - (cd ${GOPATH}/src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git)
   - go get code.google.com/p/go-uuid/uuid
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/axw/gocov/gocov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opencontrail/go-k8s-builder:1.1.0
+FROM opencontrail/go-k8s-builder
 MAINTAINER Pedro Marques <roque@juniper.net>
 RUN mkdir -p src/github.com/Juniper/contrail-kubernetes
 ADD cmd /go/src/github.com/Juniper/contrail-kubernetes/cmd

--- a/pkg/network/opencontrail/controller_dispatch.go
+++ b/pkg/network/opencontrail/controller_dispatch.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 func EqualTags(m1, m2 map[string]string, tags []string) bool {
@@ -41,11 +41,12 @@ func EqualTags(m1, m2 map[string]string, tags []string) bool {
 // IgnorePod returns true if this pod should not be managed by OpenContrail.
 // Pods that use host networking on kubelet static pods fall into this category.
 func IgnorePod(pod *api.Pod) bool {
-	if pod.Spec.HostNetwork {
+	context := pod.Spec.SecurityContext
+	if context != nil && context.HostNetwork {
 		return true
 	}
 
-	if value, ok := pod.Annotations[kubelet.ConfigMirrorAnnotationKey]; ok && value == kubelet.MirrorType {
+	if value, ok := pod.Annotations[kubetypes.ConfigMirrorAnnotationKey]; ok && value == kubetypes.MirrorType {
 		return true
 	}
 	return false

--- a/pkg/network/opencontrail/mocks/KubeClient.go
+++ b/pkg/network/opencontrail/mocks/KubeClient.go
@@ -17,7 +17,10 @@ limitations under the License.
 package mocks
 
 import (
+	"github.com/emicklei/go-restful/swagger"
+
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/version"
 )
@@ -80,7 +83,7 @@ func (c *KubeClient) PersistentVolumeClaims(namespace string) kubeclient.Persist
 func (c *KubeClient) ServerVersion() (*version.Info, error) {
 	return nil, nil
 }
-func (c *KubeClient) ServerAPIVersions() (*api.APIVersions, error) {
+func (c *KubeClient) ServerAPIVersions() (*unversioned.APIVersions, error) {
 	return nil, nil
 }
 func (c *KubeClient) ComponentStatuses() kubeclient.ComponentStatusInterface {
@@ -92,6 +95,19 @@ func (c *KubeClient) PodTemplates(namespace string) kubeclient.PodTemplateInterf
 func (c *KubeClient) ServiceAccounts(namespace string) kubeclient.ServiceAccountsInterface {
 	return nil
 }
-func (c *KubeClient) Experimental() kubeclient.ExperimentalInterface {
+
+func (c *KubeClient) ValidateComponents() (*api.ComponentStatusList, error) {
+	return nil, nil
+}
+
+func (c *KubeClient) SwaggerSchema(version string) (*swagger.ApiDeclaration, error) {
+	return nil, nil
+}
+
+func (c *KubeClient) Extensions() kubeclient.ExtensionsInterface {
+	return nil
+}
+
+func (c *KubeClient) Discovery() kubeclient.DiscoveryInterface {
 	return nil
 }

--- a/pkg/network/opencontrail/mocks/KubeServiceInterface.go
+++ b/pkg/network/opencontrail/mocks/KubeServiceInterface.go
@@ -14,8 +14,8 @@ type KubeServiceInterface struct {
 	mock.Mock
 }
 
-func (m *KubeServiceInterface) List(selector labels.Selector) (*api.ServiceList, error) {
-	ret := m.Called(selector)
+func (m *KubeServiceInterface) List(selector labels.Selector, fieldSelector fields.Selector) (*api.ServiceList, error) {
+	ret := m.Called(selector, fieldSelector)
 
 	var r0 *api.ServiceList
 	if ret.Get(0) != nil {

--- a/scripts/go-k8s-builder/Dockerfile
+++ b/scripts/go-k8s-builder/Dockerfile
@@ -5,4 +5,4 @@ RUN (cd src/github.com/Juniper && git clone https://github.com/Juniper/contrail-
 RUN wget https://github.com/Juniper/contrail-go-api/releases/download/1.0.0/contrail-go-api-generated-types-r2.20.tar.gz
 RUN (cd src && tar zxvf ../contrail-go-api-generated-types-r2.20.tar.gz)
 RUN mkdir -p src/k8s.io
-RUN (cd src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git -b v1.1.0)
+RUN (cd src/k8s.io && git clone https://github.com/kubernetes/kubernetes.git)


### PR DESCRIPTION
Docker hub opencontrail/kube-network-manager:latest will track kubernetes master branch.
For release-1.1 use tag 1.1.