### PR TITLE
Fix docker id; do not call sys.exit from setup.

### DIFF
--- a/scripts/opencontrail-kubelet/setup.py
+++ b/scripts/opencontrail-kubelet/setup.py
@@ -12,7 +12,7 @@ def requirements(filename):
 
 setuptools.setup(
     name='opencontrail-kubelet',
-    version='0.3.4',
+    version='0.3.5',
     packages=setuptools.find_packages(),
 
     # metadata


### PR DESCRIPTION
Fix docker ids (Issue #70) and do not exit from setup.
Errors during setup (e.g. annotations are missing because network-manager is down) may become harder to trace if the plugin script returns an error via sys.exit(1). kubelet sync will fail is that is the case.