### PR TITLE
Services may be created before the namespace notification is received.

### DIFF
--- a/pkg/network/opencontrail/controller.go
+++ b/pkg/network/opencontrail/controller.go
@@ -386,6 +386,7 @@ func (c *Controller) updateServicePublicIP(service *api.Service) (*types.Floatin
 // to the backends.
 func (c *Controller) addService(service *api.Service) {
 	glog.Infof("Add Service %s", service.Name)
+	c.ensureNamespace(service.Namespace)
 	serviceName := ServiceName(c.config, service.Labels)
 	err := c.serviceMgr.Create(service.Namespace, serviceName)
 	if err != nil {

--- a/pkg/network/opencontrail/controller_test.go
+++ b/pkg/network/opencontrail/controller_test.go
@@ -2070,3 +2070,45 @@ func TestPodUsing2Services(t *testing.T) {
 	}
 	shutdown <- shutdownMsg{}
 }
+
+// Issue #75
+func TestServiceBeforeNamespace(t *testing.T) {
+	kube := mocks.NewKubeClient()
+
+	client := createTestClient()
+	controller := NewTestController(kube, client, nil, nil)
+
+	service := &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "service",
+			Namespace: "newns",
+			Labels: map[string]string{
+				"name": "foo",
+			},
+		},
+		Spec: api.ServiceSpec{
+			Selector: map[string]string{
+				"name": "app1",
+			},
+			ClusterIP: "10.254.42.42",
+			Type:      api.ServiceTypeClusterIP,
+		},
+	}
+
+	ns := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name: "newns",
+		},
+	}
+	kube.PodInterface.On("List", mock.Anything).Return(&api.PodList{Items: []api.Pod{}}, nil)
+	kube.NamespaceInterface.On("Get", ns.Name).Return(ns, nil)
+
+	shutdown := make(chan struct{})
+	go controller.Run(shutdown)
+
+	controller.AddService(service)
+
+	time.Sleep(100 * time.Millisecond)
+	_, err := types.VirtualNetworkByName(client, "default-domain:newns:service-foo")
+	assert.NoError(t, err)
+}

--- a/pkg/network/opencontrail/mocks/KubeClient.go
+++ b/pkg/network/opencontrail/mocks/KubeClient.go
@@ -26,14 +26,16 @@ import (
 )
 
 type KubeClient struct {
-	PodInterface     *KubePodInterface
-	ServiceInterface *KubeServiceInterface
+	PodInterface       *KubePodInterface
+	ServiceInterface   *KubeServiceInterface
+	NamespaceInterface *KubeNamespaceInterface
 }
 
 func NewKubeClient() *KubeClient {
 	client := new(KubeClient)
 	client.PodInterface = new(KubePodInterface)
 	client.ServiceInterface = new(KubeServiceInterface)
+	client.NamespaceInterface = new(KubeNamespaceInterface)
 	return client
 }
 
@@ -70,7 +72,7 @@ func (c *KubeClient) Secrets(namespace string) kubeclient.SecretsInterface {
 }
 
 func (c *KubeClient) Namespaces() kubeclient.NamespaceInterface {
-	return nil
+	return c.NamespaceInterface
 }
 
 func (c *KubeClient) PersistentVolumes() kubeclient.PersistentVolumeInterface {

--- a/pkg/network/opencontrail/mocks/KubeNamespaceInterface.go
+++ b/pkg/network/opencontrail/mocks/KubeNamespaceInterface.go
@@ -1,0 +1,95 @@
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type KubeNamespaceInterface struct {
+	mock.Mock
+}
+
+func (m *KubeNamespaceInterface) Create(item *api.Namespace) (*api.Namespace, error) {
+	ret := m.Called(item)
+
+	var r0 *api.Namespace
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*api.Namespace)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *KubeNamespaceInterface) Get(name string) (*api.Namespace, error) {
+	ret := m.Called(name)
+
+	var r0 *api.Namespace
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*api.Namespace)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *KubeNamespaceInterface) List(opts unversioned.ListOptions) (*api.NamespaceList, error) {
+	ret := m.Called(opts)
+
+	var r0 *api.NamespaceList
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*api.NamespaceList)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *KubeNamespaceInterface) Delete(name string) error {
+	ret := m.Called(name)
+
+	r0 := ret.Error(0)
+
+	return r0
+}
+func (m *KubeNamespaceInterface) Update(item *api.Namespace) (*api.Namespace, error) {
+	ret := m.Called(item)
+
+	var r0 *api.Namespace
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*api.Namespace)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *KubeNamespaceInterface) Watch(opts unversioned.ListOptions) (watch.Interface, error) {
+	ret := m.Called(opts)
+
+	r0 := ret.Get(0).(watch.Interface)
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *KubeNamespaceInterface) Finalize(item *api.Namespace) (*api.Namespace, error) {
+	ret := m.Called(item)
+
+	var r0 *api.Namespace
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*api.Namespace)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *KubeNamespaceInterface) Status(item *api.Namespace) (*api.Namespace, error) {
+	ret := m.Called(item)
+
+	var r0 *api.Namespace
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*api.Namespace)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}


### PR DESCRIPTION
kube-network-manager logs for problem in issue #75 show that kube-system/default service is not created because the project doesn't yet exist.