### PR TITLE
Add additional support for network connectivity defined via configura…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
+**/.DS_Store
 /kube-network-manager

--- a/pkg/network/opencontrail/address_allocator.go
+++ b/pkg/network/opencontrail/address_allocator.go
@@ -71,7 +71,7 @@ func (a *AddressAllocatorImpl) initializeAllocator() {
 	glog.Infof("Created network %s", AddressAllocationNetwork)
 	obj, err = a.client.FindByUuid("virtual-network", netId)
 	if err != nil {
-		glog.Fatal("Get virtual-network %s: %v", netId, err)
+		glog.Fatalf("Get virtual-network %s: %v", netId, err)
 	}
 	a.network = obj.(*types.VirtualNetwork)
 }

--- a/pkg/network/opencontrail/controller_dispatch.go
+++ b/pkg/network/opencontrail/controller_dispatch.go
@@ -85,6 +85,8 @@ func (c *Controller) UpdatePod(oldPod, newPod *api.Pod) {
 	if IgnorePod(newPod) {
 		if !IgnorePod(oldPod) {
 			c.eventChannel <- notification{evDeletePod, oldPod}
+		} else {
+			glog.V(3).Infof("Update pod %s: ignore", newPod.Name)
 		}
 		return
 	}
@@ -95,10 +97,13 @@ func (c *Controller) UpdatePod(oldPod, newPod *api.Pod) {
 	}
 	update := false
 	if !c.podAnnotationsCheck(newPod) {
-		glog.V(3).Infof("Pod %s: annotations not current", newPod.Name)
+		glog.V(3).Infof("Pod %s: opencontrail annotations not current", newPod.Name)
 		update = true
 	} else if !EqualTags(oldPod.Labels, newPod.Labels, watchTags) {
-		glog.V(3).Infof("Pod %s: tags have changed", newPod.Name)
+		glog.V(3).Infof("Pod %s: labels have changed", newPod.Name)
+		update = true
+	} else if !EqualTags(oldPod.Annotations, newPod.Annotations, []string{c.config.NetworkAccessTag}) {
+		glog.V(3).Infof("Pod %s: annotations have changed", newPod.Name)
 		update = true
 	}
 	if update {

--- a/pkg/network/opencontrail/mocks/KubeClient.go
+++ b/pkg/network/opencontrail/mocks/KubeClient.go
@@ -113,6 +113,14 @@ func (c *KubeClient) Extensions() kubeclient.ExtensionsInterface {
 	return nil
 }
 
+func (c *KubeClient) Autoscaling() kubeclient.AutoscalingInterface {
+	return nil
+}
+
+func (c *KubeClient) Batch() kubeclient.BatchInterface {
+	return nil
+}
+
 func (c *KubeClient) Discovery() kubeclient.DiscoveryInterface {
 	return nil
 }

--- a/pkg/network/opencontrail/mocks/KubePodInterface.go
+++ b/pkg/network/opencontrail/mocks/KubePodInterface.go
@@ -4,7 +4,7 @@ import "github.com/stretchr/testify/mock"
 
 import "k8s.io/kubernetes/pkg/api"
 import "k8s.io/kubernetes/pkg/watch"
-import kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+import "k8s.io/kubernetes/pkg/client/restclient"
 
 type KubePodInterface struct {
 	mock.Mock
@@ -88,9 +88,9 @@ func (m *KubePodInterface) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
 	return r0, r1
 }
 
-func (m *KubePodInterface) GetLogs(name string, opts *api.PodLogOptions) *kubeclient.Request {
+func (m *KubePodInterface) GetLogs(name string, opts *api.PodLogOptions) *restclient.Request {
 	ret := m.Called(name, opts)
 
-	r0 := ret.Get(0).(*kubeclient.Request)
+	r0 := ret.Get(0).(*restclient.Request)
 	return r0
 }

--- a/pkg/network/opencontrail/mocks/KubeServiceInterface.go
+++ b/pkg/network/opencontrail/mocks/KubeServiceInterface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"k8s.io/kubernetes/pkg/api"
-	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -72,9 +72,9 @@ func (m *KubeServiceInterface) Watch(opts api.ListOptions) (watch.Interface, err
 	return r0, r1
 }
 
-func (m *KubeServiceInterface) ProxyGet(scheme, name, port, path string, params map[string]string) kubeclient.ResponseWrapper {
+func (m *KubeServiceInterface) ProxyGet(scheme, name, port, path string, params map[string]string) restclient.ResponseWrapper {
 	ret := m.Called(scheme, name, port, path, params)
 
-	r0 := ret.Get(0).(kubeclient.ResponseWrapper)
+	r0 := ret.Get(0).(restclient.ResponseWrapper)
 	return r0
 }

--- a/pkg/network/opencontrail/mocks/NetworkManager.go
+++ b/pkg/network/opencontrail/mocks/NetworkManager.go
@@ -1,8 +1,10 @@
 package mocks
 
-import "github.com/stretchr/testify/mock"
+import (
+	"github.com/stretchr/testify/mock"
 
-import "github.com/Juniper/contrail-go-api/types"
+	"github.com/Juniper/contrail-go-api/types"
+)
 
 type NetworkManager struct {
 	mock.Mock
@@ -109,4 +111,21 @@ func (m *NetworkManager) GetGatewayAddress(network *types.VirtualNetwork) (strin
 	r1 := ret.Error(1)
 
 	return r0, r1
+}
+
+func (m *NetworkManager) Connect(network *types.VirtualNetwork, networkFQN string) error {
+	ret := m.Called(network, networkFQN)
+	r0 := ret.Error(0)
+	return r0
+}
+func (m *NetworkManager) Disconnect(networkFQN []string, targetCDN string) error {
+	ret := m.Called(networkFQN, targetCDN)
+	r0 := ret.Error(0)
+	return r0
+}
+
+func (m *NetworkManager) DeleteConnections(network *types.VirtualNetwork, policies map[string]string) error {
+	ret := m.Called(network, policies)
+	r0 := ret.Error(0)
+	return r0
 }

--- a/pkg/network/opencontrail/opencontrail.go
+++ b/pkg/network/opencontrail/opencontrail.go
@@ -31,6 +31,12 @@ import (
 
 const (
 	MetadataAnnotationTag = "opencontrail.org/pod-state"
+
+	servicePolicyPrefix = "__svc_"
+	networkPolicyPrefix = "__net_"
+
+	DefaultPodNetworkName     = "default-network"
+	DefaultServiceNetworkName = "default"
 )
 
 // InstanceMetadata contains the information required in the kubernetes minion to

--- a/pkg/network/opencontrail/policy.go
+++ b/pkg/network/opencontrail/policy.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2016 Juniper Networks, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opencontrail
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+
+	"github.com/Juniper/contrail-go-api"
+	"github.com/Juniper/contrail-go-api/types"
+)
+
+func policyLocateRule(client contrail.ApiClient, policy *types.NetworkPolicy, lhs, rhs *types.VirtualNetwork) error {
+	return policyLocateRuleByFQN(client, policy, lhs.GetFQName(), rhs.GetFQName())
+}
+
+func policyLocateRuleByFQN(client contrail.ApiClient, policy *types.NetworkPolicy, lhsFQN, rhsFQN []string) error {
+	lhsName := strings.Join(lhsFQN, ":")
+	rhsName := strings.Join(rhsFQN, ":")
+	entries := policy.GetNetworkPolicyEntries()
+	for _, rule := range entries.PolicyRule {
+		if rule.SrcAddresses[0].VirtualNetwork == lhsName &&
+			rule.DstAddresses[0].VirtualNetwork == rhsName {
+			return nil
+		}
+	}
+	rule := new(types.PolicyRuleType)
+	rule.Protocol = "any"
+	rule.Direction = "<>"
+	rule.SrcAddresses = []types.AddressType{types.AddressType{
+		VirtualNetwork: lhsName,
+	}}
+	rule.DstAddresses = []types.AddressType{types.AddressType{
+		VirtualNetwork: rhsName,
+	}}
+	rule.SrcPorts = []types.PortType{types.PortType{StartPort: -1, EndPort: -1}}
+	rule.DstPorts = []types.PortType{types.PortType{StartPort: -1, EndPort: -1}}
+	rule.ActionList = &types.ActionListType{
+		SimpleAction: "pass",
+	}
+
+	entries.AddPolicyRule(rule)
+	policy.SetNetworkPolicyEntries(&entries)
+	err := client.Update(policy)
+	if err != nil {
+		glog.Errorf("policy-rule: %v", err)
+		return err
+	}
+	return nil
+}
+
+func removeRulesIndex(rules []types.PolicyRuleType, index int) []types.PolicyRuleType {
+	rules[index], rules = rules[len(rules)-1], rules[:len(rules)-1]
+	return rules
+}
+
+func policyDeleteRule(client contrail.ApiClient, policy *types.NetworkPolicy, lhsName, rhsName string) error {
+	entries := policy.GetNetworkPolicyEntries()
+	var index int = -1
+	for i, rule := range entries.PolicyRule {
+		if rule.SrcAddresses[0].VirtualNetwork == lhsName &&
+			rule.DstAddresses[0].VirtualNetwork == rhsName {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return nil
+	}
+	entries.PolicyRule = removeRulesIndex(entries.PolicyRule, index)
+	policy.SetNetworkPolicyEntries(&entries)
+	err := client.Update(policy)
+	if err != nil {
+		glog.Errorf("policy-rule: %v", err)
+	}
+	return err
+}
+
+func policyAttach(client contrail.ApiClient, network *types.VirtualNetwork, policy *types.NetworkPolicy) error {
+	refs, err := network.GetNetworkPolicyRefs()
+	if err != nil {
+		glog.Errorf("get network policy-refs %s: %v", network.GetName(), err)
+		return err
+	}
+	for _, ref := range refs {
+		if ref.Uuid == policy.GetUuid() {
+			return nil
+		}
+	}
+	network.AddNetworkPolicy(policy,
+		types.VirtualNetworkPolicyType{
+			Sequence: &types.SequenceType{Major: 10, Minor: 0},
+		})
+	err = client.Update(network)
+	if err != nil {
+		glog.Errorf("Update network %s policies: %v", network.GetName(), err)
+		return err
+	}
+	return nil
+}
+
+func policyDetach(client contrail.ApiClient, network *types.VirtualNetwork, policyName string) error {
+	refs, err := network.GetNetworkPolicyRefs()
+	if err != nil {
+		glog.Errorf("get network policy-refs %s: %v", network.GetName(), err)
+		return err
+	}
+	for _, ref := range refs {
+		if strings.Join(ref.To, ":") == policyName {
+			network.DeleteNetworkPolicy(ref.Uuid)
+			err := client.Update(network)
+			if err != nil {
+				glog.Errorf("Update network %s policies: %v", network.GetName(), err)
+			}
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/network/opencontrail/util.go
+++ b/pkg/network/opencontrail/util.go
@@ -53,6 +53,16 @@ func serviceIdFromName(name string) (string, string) {
 	return tuple[0], tuple[1]
 }
 
+func IsClusterService(c *Config, namespace, name string) bool {
+	for _, svc := range c.ClusterServices {
+		svc_ns, svc_name := serviceIdFromName(svc)
+		if svc_ns == namespace && svc_name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func AppendConst(slice []string, element string) []string {
 	newSlice := make([]string, len(slice), len(slice)+1)
 	copy(newSlice, slice)
@@ -64,4 +74,40 @@ func PrefixToAddressLen(subnet string) (string, int) {
 	address := prefix[0]
 	prefixlen, _ := strconv.Atoi(prefix[1])
 	return address, prefixlen
+}
+
+func escapeFQN(input []string) []string {
+	result := make([]string, 0, len(input))
+	for _, piece := range input {
+		result = append(result, strings.Replace(piece, "_", "\\_", -1))
+	}
+	return result
+}
+
+func splitEscapedString(name string) []string {
+	splitIndices := make([]int, 0)
+	last := 0
+	for {
+		ix := strings.Index(name[last:], "_")
+		if ix < 0 {
+			break
+		}
+		abs := last + ix
+		last = abs + 1
+		if name[abs-1] == '\\' {
+			continue
+		}
+		splitIndices = append(splitIndices, abs)
+	}
+
+	result := make([]string, 0)
+	prev := 0
+	for _, value := range splitIndices {
+		piece := strings.Replace(name[prev:value], "\\_", "_", -1)
+		result = append(result, piece)
+		prev = value + 1
+	}
+	piece := strings.Replace(name[prev:], "\\_", "_", -1)
+	result = append(result, piece)
+	return result
 }

--- a/pkg/network/opencontrail/util_test.go
+++ b/pkg/network/opencontrail/util_test.go
@@ -18,13 +18,17 @@ package opencontrail
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"k8s.io/kubernetes/pkg/api"
 )
 
 func TestServiceIdList(t *testing.T) {
 	config := NewConfig()
+	config.NamespaceServices = nil
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "test-xz1",
@@ -40,7 +44,7 @@ func TestServiceIdList(t *testing.T) {
 
 	// ServiceIdList is a slice; it must be passed as a pointer in order to be
 	// modified.
-	BuildPodServiceList(pod, config, &list)
+	buildPodServiceList(pod, config, &list)
 
 	if len(list) != 1 {
 		t.Errorf("expected list length 1, got %d", len(list))
@@ -51,5 +55,18 @@ func TestServiceIdList(t *testing.T) {
 	}
 	if !reflect.DeepEqual(names, []string{"service1"}) {
 		t.Errorf("expected [\"service1\"], got %+v", names)
+	}
+}
+
+func TestEscapedNames(t *testing.T) {
+	values := []string{
+		"a_b:c_d:x",
+		"a\\_b:c_d:x",
+		"foo:bar:baz",
+	}
+	for _, v := range values {
+		escapedName := escapeFQN(strings.Split(v, ":"))
+		result := splitEscapedString(strings.Join(escapedName, ":"))
+		assert.Equal(t, v, strings.Join(result, ":"))
 	}
 }


### PR DESCRIPTION
…tion.

Global-networks allow a network to be connected to all pod networks.
Namespace-services determine pod network to service network connectivity on
a per namespace basis.

Change the default labels so that they are defined in 'opencontrail.org'
namespace.