### PR TITLE
Fixes for kubernetes upstream compatability

### DIFF
--- a/pkg/network/config.go
+++ b/pkg/network/config.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/scalingdata/gcfg"
+	"gopkg.in/gcfg.v1"
 )
 
 type Config struct {

--- a/pkg/network/opencontrail/config.go
+++ b/pkg/network/opencontrail/config.go
@@ -25,7 +25,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	"github.com/scalingdata/gcfg"
+	"gopkg.in/gcfg.v1"
 
 	"github.com/Juniper/contrail-kubernetes/pkg/network"
 )

--- a/pkg/network/opencontrail/mocks/KubeClient.go
+++ b/pkg/network/opencontrail/mocks/KubeClient.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+	discovery "k8s.io/kubernetes/pkg/client/typed/discovery"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -131,7 +132,7 @@ func (c *KubeClient) Batch() kubeclient.BatchInterface {
 	return nil
 }
 
-func (c *KubeClient) Discovery() kubeclient.DiscoveryInterface {
+func (c *KubeClient) Discovery() discovery.DiscoveryInterface {
 	return nil
 }
 


### PR DESCRIPTION
Switch from obsolete "github.com/scalingdata/gcfg" to "gopkg.in/gcfg.v1" and fixes discovery client