### PR TITLE
CNI plugin implementation for contrail

### DIFF
--- a/pkg/network/cni/agent/agent.go
+++ b/pkg/network/cni/agent/agent.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2016 Juniper Networks, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+/****************************************************************************
+ * Connection handling
+ ****************************************************************************/
+/* struct to hold data for a connection to VRouter Agent */
+type Connection struct {
+	server     string
+	port       int
+	vm         string
+	dir        string // config files are stored here for persistency
+	httpClient *http.Client
+}
+
+// Make filename to store config
+func (conn *Connection) makeFileName() string {
+	return conn.dir + "/label-" + conn.vm
+}
+
+// Make URL for operation
+func (conn *Connection) makeUrl(addVm bool) string {
+	url := "http://" + conn.server + ":" + strconv.Itoa(conn.port) + "/port"
+	if addVm {
+		url = url + "/" + conn.vm
+	}
+	return url
+}
+
+func (conn *Connection) doOp(op string, addVm bool,
+	msg []byte) (*http.Response, error) {
+	url := conn.makeUrl(addVm)
+	req, err := http.NewRequest(op, url, bytes.NewBuffer(msg))
+	if err != nil {
+		return nil, fmt.Errorf("Error creating http Request <%s>",
+			err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := conn.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP operation failed <%s>", err)
+	}
+
+	return resp, nil
+}
+
+/****************************************************************************
+ * ADD message handling
+ ****************************************************************************/
+// Add Message definition
+type contrailAddMsg struct {
+	Time            string `json:"time"`
+	Vm              string `json:"vm-label"`
+	VmId            string `json:"vm-id"`
+	Nw              string `json:"network-label"`
+	HostIfName      string `json:"ifname"`
+	ContainerIfName string `json:"vm-ifname"`
+	Namespace       string `json:"namespace"`
+}
+
+// Make JSON for Add Message
+func makeAddMsg(podName, nameSpace, containerId, hostIfName,
+	containerIfName string) *contrailAddMsg {
+	t := time.Now()
+	addMsg := contrailAddMsg{Time: t.String(), Vm: podName, VmId: containerId,
+		HostIfName: hostIfName, ContainerIfName: containerIfName,
+		Namespace: nameSpace}
+	return &addMsg
+}
+
+// Store the config to file for persistency
+func (conn *Connection) addVmToFile(addMsg *contrailAddMsg) error {
+	_, err := os.Stat(conn.dir)
+	if err != nil {
+		return fmt.Errorf("Error reading VM config directory %s. Error %s",
+			conn.dir, err)
+	}
+
+	// Write file based on VM name
+	fname := conn.makeFileName()
+	rpcJson, _ := json.MarshalIndent(addMsg, "", "\t")
+	err = ioutil.WriteFile(fname, rpcJson, 0644)
+	if err != nil {
+		return fmt.Errorf("Error writing VM config file %s. Error %s",
+			fname, err)
+	}
+
+	return nil
+}
+
+func (conn *Connection) addVmToAgent(addMsg *contrailAddMsg) error {
+	msg, err := json.MarshalIndent(addMsg, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	resp, err := conn.doOp("POST", false, msg)
+	if err != nil {
+		return fmt.Errorf("Error in POST operation. %s", err)
+	}
+	defer resp.Body.Close()
+
+	if (resp.StatusCode != http.StatusOK) &&
+		(resp.StatusCode != http.StatusCreated) {
+		return fmt.Errorf("Agent returned error for VM ADD message. Code : ",
+			resp.StatusCode)
+	}
+
+	return nil
+}
+
+/* Process add of a VM. Writes config file and send message to agent */
+func (conn *Connection) AddVm(podName, nameSpace, containerId, hostIfName,
+	containerIfName string) (error, error) {
+	// Make Add Message structure
+	addMsg := makeAddMsg(podName, nameSpace, containerId, hostIfName,
+		containerIfName)
+
+	// Store config to file for persistency
+	if err := conn.addVmToFile(addMsg); err != nil {
+		// Fail adding VM if directory not present
+		return fmt.Errorf("Agent error creating config file : %s", err), nil
+	}
+
+	// Make the agent call
+	if err := conn.addVmToAgent(addMsg); err != nil {
+		/* Dont fail if agent command fails. Maybe agent is down and will
+		 * comeback shortly. When VRouter Agent comes back, PollVM will have
+		 * chance to succeed
+		 */
+		return nil, fmt.Errorf("Agent error adding VM to agent : %s", err)
+	}
+
+	return nil, nil
+}
+
+/****************************************************************************
+ * DEL message handling
+ ****************************************************************************/
+// Del Message definition
+type contrailDelMsg struct {
+	Vm string `json:"vm-label"`
+	Nw string `json:"network-label"`
+}
+
+// Make Del Message call
+func makeDelMsg(podName string) *contrailDelMsg {
+	delMsg := contrailDelMsg{Vm: podName}
+	return &delMsg
+}
+
+// Del VM config file
+func (conn *Connection) delVmToFile(delMsg *contrailDelMsg) error {
+	fname := conn.makeFileName()
+	_, err := os.Stat(fname)
+	// File not present... noting to do
+	if err != nil {
+		return fmt.Errorf("File %s not found. Error %s", fname, err)
+	}
+
+	// Delete file
+	err = os.Remove(fname)
+	if err != nil {
+		return fmt.Errorf("Error deleting file %s. Error %s", fname, err)
+	}
+
+	return nil
+}
+
+func (conn *Connection) delVmToAgent(delMsg *contrailDelMsg) error {
+	msg, err := json.MarshalIndent(delMsg, "", "\t")
+	if err != nil {
+		return fmt.Errorf("Error framing delete message %s", err)
+	}
+
+	resp, err := conn.doOp("DELETE", true, msg)
+	if err != nil {
+		return fmt.Errorf("Error in DELETE operation. %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Agent returned error for VM DElETE message. Code : ",
+			resp.StatusCode)
+	}
+	return nil
+}
+
+/* Process delete VM. The method ignores intermediate errors and does best
+ * effort cleanup
+ */
+func (conn *Connection) DelVm(podName string) error {
+	// Make del message structure
+	delMsg := makeDelMsg(podName)
+
+	var ret error
+	// Remove the configuraion file stored for persistency
+	if err := conn.delVmToFile(delMsg); err != nil {
+		ret = fmt.Errorf("Agent Error deleting config file : %s", err)
+	}
+
+	// Make the del message calll to agent
+	if err := conn.delVmToAgent(delMsg); err != nil {
+		ret = fmt.Errorf("Agent error deleting VM to agent : %s", err)
+	}
+
+	return ret
+}
+
+/****************************************************************************
+ * POLL message handling
+ ****************************************************************************/
+type Result struct {
+	Vm   string `json:"vm"`
+	Ip   string `json:"ip-address"`
+	Plen int    `json:"plen"`
+	Gw   string `json:"gateway"`
+	Dns  string `json:"dns-server"`
+	Mac  string `json:"mac-address"`
+}
+
+type contrailGetMsg struct {
+	vm string `json:"vm"`
+}
+
+func initPollVmReq(instanceId string) *contrailGetMsg {
+	return &contrailGetMsg{vm: instanceId}
+}
+
+func (conn *Connection) pollVmOnce(instanceId string) (*Result, error) {
+	delMsg := initPollVmReq(instanceId)
+	msg, err := json.MarshalIndent(delMsg, "", "\t")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := conn.doOp("GET", true, msg)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error polling VM. Status ", resp.StatusCode)
+	}
+
+	var result Result
+	var body []byte
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (conn *Connection) GetVmiInfo(instanceId, ifName string,
+	delay string, count int) (*Result, error) {
+	var msg string
+	for i := 0; i < count; i++ {
+		result, err := conn.pollVmOnce(instanceId)
+		if err == nil {
+			return result, nil
+		}
+
+		msg = err.Error()
+		var d time.Duration
+		d, err = time.ParseDuration(delay)
+		if err != nil {
+			d, err = time.ParseDuration(delay)
+		}
+
+		time.Sleep(d)
+	}
+
+	return nil, fmt.Errorf("Failed in PollVM for instance %s. Error %s",
+		instanceId, msg)
+}
+
+/****************************************************************************
+ * Connection handlers
+ ****************************************************************************/
+func (conn *Connection) Close() error {
+	return nil
+}
+
+func Init(vm, dir, server string, port int) (*Connection, error) {
+	// Verify directory
+	if dir == "" {
+		return nil, fmt.Errorf("Agent Error : Directory name not specified")
+	}
+
+	httpClient := new(http.Client)
+	conn := Connection{server: server, port: port, vm: vm, dir: dir,
+		httpClient: httpClient}
+	return &conn, nil
+}

--- a/pkg/network/cni/args/args.go
+++ b/pkg/network/cni/args/args.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2016 Juniper Networks, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Common code to parse agruments for both Kubernetes and Mesos. */
+package args
+
+import (
+	"../agent"
+	"encoding/json"
+	"fmt"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"net"
+	"strings"
+)
+
+/****************************************************************************
+ * Argument handling
+ ****************************************************************************/
+const modek8s = "kubernetes"
+const modeMesos = "mesos"
+const k8sDir = "/var/contrail/k8s"
+const mesosDir = "/var/contrail/mesos"
+const pollTimeout = "100ms"
+const pollRetries = 10
+const vrouterIp = "127.0.0.1"
+const vrouterPort = 9091
+const logDir = "/var/log/contrail/cni"
+const logLevel = "0"
+
+/* Example configuration for Contrail
+    {
+        "cniVersion": "0.2.0",
+        "contrail" : {
+            "vrouter" : {
+                "ip" : "127.0.0.1",
+                "port" : 9091,
+				"timeout" : "2000ms"
+				"retries" : 10
+            },
+            "mode" : "k8s"
+            "mtu" : 1500
+			"dir" : "/var/contrail/vm",
+			"log" : {
+				"dir" : "/var/log/contrail/cni",
+				"level" : "2"
+			},
+        },
+
+        "name": "contrail",
+        "type": "contrail"
+    }
+*/
+
+// Logging arguments
+type LoggingArgs struct {
+	Dir   string `json:"dir"`
+	Level string `json:"level"`
+}
+
+// Definitions to get VRouter related parameters from json data
+type VRouterArgs struct {
+	Ip          string `json:"ip"`
+	Port        int    `json:"port"`
+	PollTimeout string `json:"pollTimeout"`
+	PollRetries int    `json:"pollRetries"`
+}
+
+// Contrail specific arguments
+type ContrailArgs struct {
+	VRouterArgs VRouterArgs `json:"vrouter"`
+	Mode        string      `json:"mode"`
+	Mtu         int         `json:"mtu"`
+	Dir         string      `json:"dir"`
+	Logging     LoggingArgs `json:"log"`
+}
+
+// Kubernetes specific arguments
+type K8SArgs struct {
+	NameSpace string
+	PodName   string
+}
+
+// Definition of json data in STDIN
+type CniArgs struct {
+	ContrailArgs ContrailArgs `json:"contrail"`
+	ContainerID  string
+	IfName       string
+	Netns        string
+	K8SArgs      K8SArgs
+}
+
+/*
+ * Get Kubernetes specific arguments
+ * Format of arguments in case of kubernetes is
+ * "IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=hello-world-1-81nl8;
+ *  K8S_POD_INFRA_CONTAINER_ID=<container-id>"
+ */
+func (k8sArgs *K8SArgs) getK8sArgs(args *skel.CmdArgs) {
+	cniArgs := strings.Split(args.Args, ";")
+	for _, v := range cniArgs {
+		a := strings.Split(v, "=")
+		if len(a) >= 2 {
+			if a[0] == "K8S_POD_NAMESPACE" {
+				k8sArgs.NameSpace = a[1]
+			}
+			if a[0] == "K8S_POD_NAME" {
+				k8sArgs.PodName = a[1]
+			}
+		}
+	}
+}
+
+// Fetch all parameters. Includes parameters from STDIN and Environemnt vars
+func Get(args *skel.CmdArgs) (*CniArgs, error) {
+	// Set defaults
+	vrouterArgs := VRouterArgs{Ip: vrouterIp, Port: vrouterPort,
+		PollTimeout: pollTimeout, PollRetries: pollRetries}
+	logArgs := LoggingArgs{Dir: logDir, Level: logLevel}
+	contrailArgs := ContrailArgs{VRouterArgs: vrouterArgs, Dir: k8sDir,
+		Logging: logArgs}
+	cniArgs := &CniArgs{ContrailArgs: contrailArgs}
+
+	// Parse json data
+	if err := json.Unmarshal(args.StdinData, cniArgs); err != nil {
+		msg := fmt.Sprintf("Invalid JSon string. Error %v : Message %s\n",
+			err, args.StdinData)
+		return nil, fmt.Errorf(msg)
+	}
+
+	cniArgs.ContainerID = args.ContainerID
+	cniArgs.Netns = args.Netns
+	cniArgs.IfName = args.IfName
+	// Kubernetes specific parameters are passed in environment variable.
+	// Get Kubernetes specific parameters from environment variable
+	cniArgs.K8SArgs.getK8sArgs(args)
+	return cniArgs, nil
+}
+
+// Convert cniArgs from VRouter format to CNI format
+func VRouterResultToCniResult(agent *agent.Result) *types.Result {
+	mask := net.CIDRMask(agent.Plen, 32)
+	ipv4 := types.IPConfig{IP: net.IPNet{IP: net.ParseIP(agent.Ip),
+		Mask: mask}, Gateway: net.ParseIP(agent.Gw)}
+	result := &types.Result{IP4: &ipv4}
+
+	_, defaultNet, err := net.ParseCIDR("0.0.0.0/0")
+	if err != nil {
+		return nil
+	}
+	result.IP4.Routes = append(result.IP4.Routes,
+		types.Route{Dst: *defaultNet, GW: result.IP4.Gateway})
+
+	result.DNS.Nameservers = append(result.DNS.Nameservers, agent.Dns)
+	return result
+}

--- a/pkg/network/cni/cni/cni.go
+++ b/pkg/network/cni/cni/cni.go
@@ -118,8 +118,8 @@ func processContainerAdd(netns ns.NetNS, cniArgs *args.CniArgs, mac string,
 func processVRouterAdd(agent *agent.Connection, cniArgs *args.CniArgs,
 	hostIfName string) (error, error) {
 	// Send AddVm IPC to contrail-vrouter agent
-	return agent.AddVm(cniArgs.K8SArgs.PodName, cniArgs.Netns,
-		cniArgs.ContainerID, hostIfName, cniArgs.IfName)
+	return agent.AddVm(cniArgs.K8SArgs.PodUuid, cniArgs.K8SArgs.PodName,
+		cniArgs.Netns, cniArgs.ContainerID, hostIfName, cniArgs.IfName)
 }
 
 // Get VMI parameters from VRouter
@@ -155,7 +155,7 @@ func CmdAdd(skelArgs *skel.CmdArgs) error {
 	defer netns.Close()
 
 	// Initialize connection to VRouter
-	connection, err := agent.Init(cniArgs.K8SArgs.PodName,
+	connection, err := agent.Init(cniArgs.K8SArgs.PodUuid,
 		cniArgs.ContrailArgs.Dir, cniArgs.ContrailArgs.VRouterArgs.Ip,
 		cniArgs.ContrailArgs.VRouterArgs.Port)
 	if err != nil {
@@ -170,7 +170,7 @@ func CmdAdd(skelArgs *skel.CmdArgs) error {
 	result, err := getVmiFromVRouter(connection, cniArgs)
 	if err != nil {
 		glog.Error(fmt.Sprintf("Error querying vmi <%s> from VRouter : %s",
-			cniArgs.K8SArgs.PodName, err.Error()))
+			cniArgs.K8SArgs.PodUuid, err.Error()))
 		return err
 	}
 
@@ -183,14 +183,7 @@ func CmdAdd(skelArgs *skel.CmdArgs) error {
 		typesResult)
 	if err != nil {
 		glog.Error(fmt.Sprintf("Error modifying container <%s> : %s",
-			cniArgs.K8SArgs.PodName, err.Error()))
-		return err
-	}
-
-	connection, err = ipc.Init("",
-		cniArgs.ContrailArgs.Dir, cniArgs.ContrailArgs.VRouterArgs.Ip,
-		cniArgs.ContrailArgs.VRouterArgs.Port)
-	if err != nil {
+			cniArgs.K8SArgs.PodUuid, err.Error()))
 		return err
 	}
 
@@ -248,7 +241,7 @@ func processContainerDel(netns ns.NetNS, cniArgs *args.CniArgs) error {
 // VRouter DEL handler
 func processVRouterDel(agent *agent.Connection, cniArgs *args.CniArgs) error {
 	// Let VRouter handle DEL command
-	return agent.DelVm(cniArgs.K8SArgs.PodName)
+	return agent.DelVm(cniArgs.K8SArgs.PodUuid)
 }
 
 // DEL command handler
@@ -276,7 +269,7 @@ func CmdDel(skelArgs *skel.CmdArgs) error {
 		}
 	}
 
-	connection, err := agent.Init(cniArgs.K8SArgs.PodName,
+	connection, err := agent.Init(cniArgs.K8SArgs.PodUuid,
 		cniArgs.ContrailArgs.Dir, cniArgs.ContrailArgs.VRouterArgs.Ip,
 		cniArgs.ContrailArgs.VRouterArgs.Port)
 	if err != nil {

--- a/pkg/network/cni/cni/cni.go
+++ b/pkg/network/cni/cni/cni.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2016 Juniper Networks, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Common CNI plugin for Kubernetes and Mesos. */
+package cni
+
+import (
+	"../agent"
+	"../args"
+	"flag"
+	"fmt"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/golang/glog"
+	"github.com/vishvananda/netlink"
+	"net"
+)
+
+const CniVersion = "0.2.0"
+
+/*
+ * Apply logging configuration. We use glog packet for logging.
+ * glog supports log-dir and log-level as arguments only. Simulate argument
+ * passing to glog module
+ */
+func applyLogging(args args.LoggingArgs) {
+	flag.Parse()
+	flag.Lookup("log_dir").Value.Set(args.Dir)
+	flag.Lookup("v").Value.Set(args.Level)
+	return
+}
+
+// Common code for both delete and add
+func cmdCommon(skelArgs *skel.CmdArgs, cmd string) (*args.CniArgs, error) {
+	cniArgs, err := args.Get(skelArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set logging
+	applyLogging(cniArgs.ContrailArgs.Logging)
+	glog.V(2).Info(fmt.Sprintf("%s with ContainerId : <%s>, Netns : <%s>, IfName : <%s>, Args <%s>, Stdin %s\n",
+		cmd, skelArgs.ContainerID, skelArgs.Netns, skelArgs.IfName,
+		skelArgs.Args, string(skelArgs.StdinData)))
+	glog.V(2).Info(fmt.Sprintf("Parsed information %+v\n", cniArgs))
+
+	return cniArgs, nil
+}
+
+/****************************************************************************
+ * ADD message handlers
+ ****************************************************************************/
+// Container handling for add message
+// 1. Create veth-pair interface
+// 2. Set MAC address for interface inside the container
+// 3. Apply IPAM configuration including,
+//    - Assign IP address to the interface inside container
+//    - Create the veth pairs and get host-os name for interface
+func processContainerAdd(netns ns.NetNS, cniArgs *args.CniArgs, mac string,
+	typesResult *types.Result) (string, error) {
+	// Validate MAC address
+	hwAddr, mac_err := net.ParseMAC(mac)
+	if mac_err != nil {
+		return "", fmt.Errorf("Error parsing MAC address ", mac, " Error ",
+			mac_err)
+	}
+
+	var hostIfName string
+	// Configure the container
+	err := netns.Do(func(hostNS ns.NetNS) error {
+		// create veth pair in container and move host end into host netns
+		link, _, err := ip.SetupVeth(cniArgs.IfName, cniArgs.ContrailArgs.Mtu,
+			hostNS)
+		if err != nil {
+			return err
+		}
+		hostIfName = link.Attrs().Name
+
+		// Update MAC address for the interface
+		err = ip.SetHWAddr(cniArgs.IfName, hwAddr)
+		if err != nil {
+			return err
+		}
+
+		// Configure IPAM attributes
+		err = ipam.ConfigureIface(cniArgs.IfName, typesResult)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return hostIfName, nil
+}
+
+// VRouter handling for add message
+func processVRouterAdd(agent *agent.Connection, cniArgs *args.CniArgs,
+	hostIfName string) (error, error) {
+	// Send AddVm IPC to contrail-vrouter agent
+	return agent.AddVm(cniArgs.K8SArgs.PodName, cniArgs.Netns,
+		cniArgs.ContainerID, hostIfName, cniArgs.IfName)
+}
+
+// Get VMI parameters from VRouter
+func getVmiFromVRouter(agent *agent.Connection,
+	cniArgs *args.CniArgs) (*agent.Result, error) {
+	result, err := agent.GetVmiInfo(cniArgs.ContainerID, cniArgs.IfName,
+		cniArgs.ContrailArgs.VRouterArgs.PollTimeout,
+		cniArgs.ContrailArgs.VRouterArgs.PollRetries)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// ADD command handler
+func CmdAdd(skelArgs *skel.CmdArgs) error {
+	cniArgs, err := cmdCommon(skelArgs, "Add")
+	defer glog.Flush()
+	if err != nil {
+		// Error parsing arguments is treated as Fatal error
+		return err
+	}
+
+	// Get handle to the Namespace
+	netns, err := ns.GetNS(cniArgs.Netns)
+	if err != nil {
+		// Error in opening namespace. Treat as fatal error
+		msg := fmt.Sprintf("Failed to open netns %s: %v", cniArgs.Netns, err)
+		glog.Error(msg)
+		return fmt.Errorf(msg)
+	}
+	defer netns.Close()
+
+	// Initialize connection to VRouter
+	connection, err := agent.Init(cniArgs.K8SArgs.PodName,
+		cniArgs.ContrailArgs.Dir, cniArgs.ContrailArgs.VRouterArgs.Ip,
+		cniArgs.ContrailArgs.VRouterArgs.Port)
+	if err != nil {
+		glog.Error(fmt.Sprintf("Error initializing connection : %s",
+			err.Error()))
+		return err
+	}
+	defer connection.Close()
+
+	// We need to get few arguments such as MAC address from VRouter. So, fetch
+	// VMI parametrs from VRouter first
+	result, err := getVmiFromVRouter(connection, cniArgs)
+	if err != nil {
+		glog.Error(fmt.Sprintf("Error querying vmi <%s> from VRouter : %s",
+			cniArgs.K8SArgs.PodName, err.Error()))
+		return err
+	}
+
+	// Translate result from VRouter format to Cni-Types
+	typesResult := args.VRouterResultToCniResult(result)
+
+	// Create the veth pairs and configure them
+	// The container-part is added to the nets provided to CNI
+	hostIfName, err := processContainerAdd(netns, cniArgs, result.Mac,
+		typesResult)
+	if err != nil {
+		glog.Error(fmt.Sprintf("Error modifying container <%s> : %s",
+			cniArgs.K8SArgs.PodName, err.Error()))
+		return err
+	}
+
+	connection, err = ipc.Init("",
+		cniArgs.ContrailArgs.Dir, cniArgs.ContrailArgs.VRouterArgs.Ip,
+		cniArgs.ContrailArgs.VRouterArgs.Port)
+	if err != nil {
+		return err
+	}
+
+	// Send add message to vrouter
+	var warn error
+	err, warn = processVRouterAdd(connection, cniArgs, hostIfName)
+	if err != nil {
+		glog.Error(fmt.Sprintf("Error adding interface to VRouter : %s",
+			err.Error()))
+		return err
+	}
+
+	if warn != nil {
+		glog.Warning(fmt.Sprintf("Error adding interface to VRouter : %s",
+			warn.Error()))
+	}
+	glog.V(2).Info(fmt.Sprintf("Result : %+v", typesResult))
+	return typesResult.Print()
+}
+
+/****************************************************************************
+ * DEL message handlers
+ ****************************************************************************/
+// Container DEL handler
+// Deletes interface from the container
+func processContainerDel(netns ns.NetNS, cniArgs *args.CniArgs) error {
+	// Remove interface from the netlink
+	var ipn *net.IPNet
+	err := ns.WithNetNSPath(cniArgs.Netns, func(_ ns.NetNS) error {
+		// Get the link
+		iface, err := netlink.LinkByName(cniArgs.IfName)
+		if err != nil {
+			// Link already deleted. Nothing else to do
+			return nil
+		}
+
+		// Delete the link from container
+		ipn, err = ip.DelLinkByNameAddr(cniArgs.IfName, netlink.FAMILY_V4)
+		if err != nil {
+			if err = netlink.LinkDel(iface); err != nil {
+				return fmt.Errorf("failed to delete %q: %v", cniArgs.IfName,
+					err)
+			}
+		}
+
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// VRouter DEL handler
+func processVRouterDel(agent *agent.Connection, cniArgs *args.CniArgs) error {
+	// Let VRouter handle DEL command
+	return agent.DelVm(cniArgs.K8SArgs.PodName)
+}
+
+// DEL command handler
+// Do best effort of cleanup ignoring any intermediate errors
+func CmdDel(skelArgs *skel.CmdArgs) error {
+	var ret error
+	cniArgs, err := cmdCommon(skelArgs, "Add")
+	defer glog.Flush()
+	if err != nil {
+		// Error parsing arguments is treated as Fatal error
+		return err
+	}
+
+	// Get handle to the Namespace
+	netns, err := ns.GetNS(cniArgs.Netns)
+	if err == nil {
+		defer netns.Close()
+		// Cleanup interfaces created
+		// If namespace cannot be open, then most likely the interfaces are
+		// already deleted. So no container cleanup is needed
+		err = processContainerDel(netns, cniArgs)
+		if err != nil {
+			ret = fmt.Errorf("Error in cleanup of interfaces for DEL. Error ",
+				err)
+		}
+	}
+
+	connection, err := agent.Init(cniArgs.K8SArgs.PodName,
+		cniArgs.ContrailArgs.Dir, cniArgs.ContrailArgs.VRouterArgs.Ip,
+		cniArgs.ContrailArgs.VRouterArgs.Port)
+	if err != nil {
+		// Initialize connection to VRouter
+		glog.Error(fmt.Sprintf("Error initializing connection : %s",
+			err.Error()))
+	}
+	if err == nil {
+		defer connection.Close()
+	}
+
+	// VRouter handling next
+	err = processVRouterDel(connection, cniArgs)
+	if err != nil {
+		ret = fmt.Errorf("Error in VRouter cleanup for DEL. Error ", err)
+	}
+
+	if err != nil {
+		glog.Error(ret.Error())
+	} else {
+		glog.V(2).Info(fmt.Sprintf("Del successful"))
+	}
+
+	return ret
+}

--- a/pkg/network/cni/opencontrail.go
+++ b/pkg/network/cni/opencontrail.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"./cni"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+/****************************************************************************
+ * Main
+ ****************************************************************************/
+func main() {
+	// Let CNI skeletal code handle demux based on env variables
+	skel.PluginMain(cni.CmdAdd, cni.CmdDel,
+		version.PluginSupports(cni.CniVersion))
+}

--- a/pkg/network/cni/test/contrail-server.go
+++ b/pkg/network/cni/test/contrail-server.go
@@ -1,0 +1,64 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+type vmResp struct {
+	Vm   string `json:"vm"`
+	Ip   string `json:"ip-address"`
+	Plen int    `json:"plen"`
+	Gw   string `json:"gateway"`
+	Dns  string `json:"dns-server"`
+	Mac  string `json:"mac-address"`
+}
+
+type statusResp struct {
+	Status string `json:"status"`
+}
+
+var addr int = 3
+
+func vmServer(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case "GET":
+		fmt.Println("GET request")
+		ip := "1.1.1." + strconv.Itoa(addr)
+		addr += 1
+		resp := vmResp{Vm: "VM", Ip: ip, Plen: 24, Gw: "1.1.1.1",
+			Dns: "1.1.1.2", Mac: "00:00:00:00:00:01"}
+		msg, _ := json.Marshal(resp)
+		io.WriteString(w, string(msg))
+		return
+
+	case "POST":
+		fmt.Println("POST request")
+		resp := statusResp{Status: "OK"}
+		msg, _ := json.Marshal(resp)
+		io.WriteString(w, string(msg))
+		return
+
+	case "DELETE":
+		fmt.Println("DELETE request")
+		resp := statusResp{Status: "OK"}
+		msg, _ := json.Marshal(resp)
+		io.WriteString(w, string(msg))
+		return
+	default:
+		fmt.Println("Unkown command")
+	}
+}
+
+func main() {
+	http.HandleFunc("/port/", vmServer)
+	http.HandleFunc("/port", vmServer)
+	http.ListenAndServe(":9060", nil)
+}

--- a/pkg/network/cni/test/contrail-test.sh
+++ b/pkg/network/cni/test/contrail-test.sh
@@ -1,0 +1,10 @@
+#/bin/bash
+#ip netns add TestNS
+export GOPATH=$HOME/k8s/lib
+export CNI_COMMAND=$1
+export CNI_NETNS="/var/run/netns/TestNS"
+export CNI_IFNAME="eth0"
+export CNI_PATH="/test"
+export CNI_CONTAINERID="1234"
+export CNI_ARGS="IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=hello-world-1-81nl8;K8S_POD_INFRA_CONTAINER_ID=4209d77cedfc320540b55d52a7d19b3c5f8cb99e29ed9842eeb8e426608b0f6a"
+$HOME/k8s/go/bin/go run contrail.go < contrail.conf

--- a/pkg/network/cni/test/contrail.conf
+++ b/pkg/network/cni/test/contrail.conf
@@ -1,0 +1,13 @@
+{
+    "cniVersion": "0.2.0",
+    "contrail" : {
+        "vrouter" : {
+            "ip" : "127.0.0.1",
+            "port" : 9090
+        },
+        "dir" : "/var/lib/contrail/ports"
+    },
+
+    "name": "contrail",
+    "type": "contrail"
+}


### PR DESCRIPTION
It has 3 modules

args  : Responsible to parse arguments including CNI environment
         variables and config json
cni   : Responsible to implement CNI part including creating tap
        interface, assign mac-address
agent : Responsible for communication between CNI and vrouter-agent

The plugin runs following algorithm for port-add
    1. Query the configuration for port from vrouter-agent
    2. Create TAP interface. Assign mac-address for interface from (1)
    3. Create port-configuration file in /var/lib/contrail/port directory
    4. Send port-add command to vrouter-agent

The plugin runs following algorithm for port-del
    1. Remove the port-config file from /var/lib/contrail/port directory
    1. Send port-delete command to vrouter-agent